### PR TITLE
feat: add method to check whether websocket is open

### DIFF
--- a/src/websocket-transporter.ts
+++ b/src/websocket-transporter.ts
@@ -50,4 +50,8 @@ export class WebsocketTransporter extends YDocMessageTransporter {
       throw error
     }
   }
+
+  public isWebSocketOpen(): boolean {
+    return this.websocket?.readyState === WebSocket.OPEN
+  }
 }


### PR DESCRIPTION
### Description
This PR adds a method `isWebSocketOpen` for classes extending the WebsocketTransporter to check whether they can send data over the socket without any errors.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added changes
- [x] I read the [contribution documentation](https://github.com/hedgedoc/html-to-react/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.

### Related Issue(s)
hedgedoc/react-client#2322
